### PR TITLE
new moving average filter for integration.  Supports reset

### DIFF
--- a/grc/CMakeLists.txt
+++ b/grc/CMakeLists.txt
@@ -34,5 +34,6 @@ install(FILES
     radio_astro_ra_integrate.block.yml
     radio_astro_ra_vave.block.yml
     radio_astro_ra_vmedian.block.yml
-    radio_astro_integration.block.yml DESTINATION share/gnuradio/grc/blocks
+    radio_astro_integration.block.yml
+    radio_astro_vector_moving_average.block.yml DESTINATION share/gnuradio/grc/blocks
 )

--- a/grc/radio_astro_vector_moving_average.block.yml
+++ b/grc/radio_astro_vector_moving_average.block.yml
@@ -1,0 +1,49 @@
+id: radio_astro_vector_moving_average
+label: vector_moving_average
+category: '[radio_astro]'
+
+templates:
+  imports: import radio_astro
+  make: radio_astro.vector_moving_average(${vec_length}, ${averaging_length}, ${reset_integration})
+  callbacks:
+    - set_reset_integration(${reset_integration})
+
+#  Make one 'parameters' list entry for every parameter you want settable from the GUI.
+#     Keys include:
+#     * id (makes the value accessible as \$keyname, e.g. in the make entry)
+#     * label (label shown in the GUI)
+#     * dtype (e.g. int, float, complex, byte, short, xxx_vector, ...)
+parameters:
+- id: vec_length
+  label: Vector Length
+  dtype: int
+- id: averaging_length
+  label: Number of averages
+  dtype: int
+
+- id: reset_integration
+  label: Reset Integration
+  dtype: int
+
+#  Make one 'inputs' list entry per input and one 'outputs' list entry per output.
+#  Keys include:
+#      * label (an identifier for the GUI)
+#      * domain (optional - stream or message. Default is stream)
+#      * dtype (e.g. int, float, complex, byte, short, xxx_vector, ...)
+#      * vlen (optional - data stream vector length. Default is 1)
+#      * optional (optional - set to 1 for optional inputs. Default is 0)
+inputs:
+- label: in
+  domain: stream
+  dtype: float
+  vlen: ${vec_length}
+
+outputs:
+- label: out
+  domain: stream
+  dtype: float
+  vlen: ${vec_length}
+
+#  'file_format' specifies the version of the GRC yml format used in the file
+#  and should usually not be changed.
+file_format: 1

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -47,7 +47,8 @@ GR_PYTHON_INSTALL(
     ra_vave.py
     ra_vmedian.py 
     powerSpectrum.py
-    integration.py DESTINATION ${GR_PYTHON_DIR}/radio_astro
+    integration.py
+    vector_moving_average.py DESTINATION ${GR_PYTHON_DIR}/radio_astro
 )
 
 ########################################################################
@@ -73,3 +74,4 @@ GR_ADD_TEST(qa_ra_integrate ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/qa_
 GR_ADD_TEST(qa_ra_vave ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/qa_ra_vave.py)
 GR_ADD_TEST(qa_ra_vmedian ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/qa_ra_vmedian.py)
 GR_ADD_TEST(qa_integration ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/qa_integration.py)
+GR_ADD_TEST(qa_vector_moving_average ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/qa_vector_moving_average.py)

--- a/python/__init__.py
+++ b/python/__init__.py
@@ -45,4 +45,5 @@ from .ra_integrate import ra_integrate
 from .ra_vave import ra_vave
 from .ra_vmedian import ra_vmedian
 from .integration import integration
+from .vector_moving_average import vector_moving_average
 #

--- a/python/qa_vector_moving_average.py
+++ b/python/qa_vector_moving_average.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright 2020 DSPIRA.
+#
+# This is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3, or (at your option)
+# any later version.
+#
+# This software is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this software; see the file COPYING.  If not, write to
+# the Free Software Foundation, Inc., 51 Franklin Street,
+# Boston, MA 02110-1301, USA.
+#
+
+from gnuradio import gr, gr_unittest
+from gnuradio import blocks
+from vector_moving_average import vector_moving_average
+
+class qa_vector_moving_average(gr_unittest.TestCase):
+
+    def setUp(self):
+        self.tb = gr.top_block()
+
+    def tearDown(self):
+        self.tb = None
+
+    def test_001_t(self):
+        # set up fg
+        self.tb.run()
+        # check data
+
+
+if __name__ == '__main__':
+    gr_unittest.run(qa_vector_moving_average)

--- a/python/vector_moving_average.py
+++ b/python/vector_moving_average.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright 2020 DSPIRA.
+#
+# This is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3, or (at your option)
+# any later version.
+#
+# This software is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this software; see the file COPYING.  If not, write to
+# the Free Software Foundation, Inc., 51 Franklin Street,
+# Boston, MA 02110-1301, USA.
+#
+
+
+import numpy as np
+from gnuradio import gr
+
+class vector_moving_average(gr.sync_block):
+    """
+    docstring for block vector_moving_average
+    """
+    def __init__(self, vec_length, averaging_length, reset_integration):
+        gr.sync_block.__init__(self,
+            name="vector moving average",
+            in_sig=[(np.float32, int(vec_length))],
+            out_sig=[(np.float32, int(vec_length))])
+        #self.set_history(averaging_length)
+        self.averaging_length = averaging_length
+        self.vec_length = vec_length
+        self._sum1 = np.zeros(self.vec_length)
+        self.data_history = np.zeros((self.averaging_length, self.vec_length))
+        self.history_count = 0
+        self.start_count = 0
+        self.reset_integration = reset_integration
+
+
+    def work(self, input_items, output_items):
+        out = output_items[0]
+        # Maybe should check here if really averaging length long?
+        #print(input_items[0].shape)
+        #seems gnuradio gives averaging_length vectors right away, 
+        #with zeros till all data there.
+        self.data_history[self.history_count] = input_items[0]
+        self.history_count += 1
+        if self.history_count == self.averaging_length:
+             self.history_count = 0
+
+        self._sum1 = self.data_history.sum(axis=0)
+        if self.start_count < self.averaging_length:
+            self.start_count += 1
+            output_items[0][:] = self._sum1/self.start_count
+        else:
+            output_items[0][:] = self._sum1/self.averaging_length
+        return len(output_items[0])
+
+    def set_reset_integration(self, reset_integration):
+        self.data_history = np.zeros((self.averaging_length, self.vec_length))
+        self.history_count = 0
+        self.start_count = 0
+        # I don't actually use reset integration variable, just the callback.
+        print("Reset Integrations")


### PR DESCRIPTION
use in conjunction with a selector block and the integrate block to have a 'fast' and 'slow' integration.  Could also just use the 'slow' and hit reset after moving to new locations.