### PR TITLE
Update png_print_spectrum.py

### DIFF
--- a/python/radio_astro/png_print_spectrum.py
+++ b/python/radio_astro/png_print_spectrum.py
@@ -10,6 +10,8 @@ from gnuradio import gr
 import time
 from datetime import datetime
 try:
+    import matplotlib
+    matplotlib.use('Agg')
     import matplotlib.pyplot as plt
     canPlot = True
 except:


### PR DESCRIPTION
fix to use no gui backend to prevent crash on newer versions when trying to print png.